### PR TITLE
tutorial 6: reverse the cone so that the center-of-mass plot is reproduced

### DIFF
--- a/doc/tutorials/06-active_matter/EXERCISES/rectification_geometry.py
+++ b/doc/tutorials/06-active_matter/EXERCISES/rectification_geometry.py
@@ -107,7 +107,7 @@ shift = 0.25*orad*cos(angle)
 
 hollow_cone = HollowCone(
     center=(length/2.0 - shift, (diameter+4)/2.0, (diameter+4)/2.0),
-    axis=[1,0,0],
+    axis=[-1,0,0],
     outer_radius=orad,
     inner_radius=irad,
     width=2.0,

--- a/doc/tutorials/06-active_matter/SOLUTIONS/rectification_geometry.py
+++ b/doc/tutorials/06-active_matter/SOLUTIONS/rectification_geometry.py
@@ -107,7 +107,7 @@ shift = 0.25*orad*cos(angle)
 
 hollow_cone = HollowCone(
     center=(length/2.0 - shift, (diameter+4)/2.0, (diameter+4)/2.0),
-    axis=[1,0,0],
+    axis=[-1,0,0],
     outer_radius=orad,
     inner_radius=irad,
     width=2.0,

--- a/doc/tutorials/06-active_matter/SOLUTIONS/rectification_simulation.py
+++ b/doc/tutorials/06-active_matter/SOLUTIONS/rectification_simulation.py
@@ -130,7 +130,7 @@ shift = 0.25*orad*cos(angle)
 
 hollow_cone = HollowCone(
     center=(length/2.0 - shift, (diameter+4)/2.0, (diameter+4)/2.0),
-    axis=[1,0,0],
+    axis=[-1,0,0],
     outer_radius=orad,
     inner_radius=irad,
     width=2.0,


### PR DESCRIPTION
Fix for https://github.com/hmenke/espresso/pull/4